### PR TITLE
add highlights to games endpoint

### DIFF
--- a/app/game/game.controller.js
+++ b/app/game/game.controller.js
@@ -79,7 +79,7 @@ module.exports = (db, Sentry) => {
                 }
 
                 let games = await db.any(`
-                    SELECT g.id, g.season, g.week, g.season_type, g.start_date, g.start_time_tbd, g.neutral_site, g.conference_game, g.attendance, v.id as venue_id, v.name as venue, home.id as home_id, home.school as home_team, hc.name as home_conference, gt.points as home_points, gt.line_scores as home_line_scores, gt.win_prob AS home_post_win_prob, away.id AS away_id, away.school as away_team, ac.name as away_conference, gt2.points as away_points, gt2.line_scores as away_line_scores, gt2.win_prob AS away_post_win_prob, g.excitement as excitement_index
+                    SELECT g.id, g.season, g.week, g.season_type, g.start_date, g.start_time_tbd, g.neutral_site, g.conference_game, g.attendance, v.id as venue_id, v.name as venue, home.id as home_id, home.school as home_team, hc.name as home_conference, gt.points as home_points, gt.line_scores as home_line_scores, gt.win_prob AS home_post_win_prob, away.id AS away_id, away.school as away_team, ac.name as away_conference, gt2.points as away_points, gt2.line_scores as away_line_scores, gt2.win_prob AS away_post_win_prob, g.excitement as excitement_index, g.highlights
                     FROM game g
                         INNER JOIN game_team gt ON g.id = gt.game_id AND gt.home_away = 'home'
                         INNER JOIN team home ON gt.team_id = home.id

--- a/swagger.json
+++ b/swagger.json
@@ -2786,6 +2786,9 @@
         },
         "excitement_index": {
           "type": "number"
+        },
+        "highlights": {
+          "type": "string"
         }
       }
     },

--- a/swagger.yml
+++ b/swagger.yml
@@ -1922,6 +1922,8 @@ definitions:
         type: number
       excitement_index:
         type: number
+      highlights:
+        type: string
   TeamRecord:
     type: object
     properties:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I've added the field highlights to the response of the games endpoint
It's the Youtube video id of the highlights of the appropiate game. 
e.g.: Highlight of game 401056697 : HcolP0a3BsQ -> https://www.youtube.com/watch?v=HcolP0a3BsQ
I've attached a SQL file with the ALTER TABLE command and INSERT statements  for all the highlights I have

## Motivation and Context
I'll find it cool if you have the highlights of game in the API response

## How Has This Been Tested?
A general test of the games endpoint was already in place

## Screenshots (if appropriate):

## Types of changes
-  Breaking change (fix or feature that would cause existing functionality to not work as expected)
API would break if you don't execute the ALTER TABLE statement of the SQL file

## Checklist:
-  My code follows the code style of this project.
- My change requires a change to the documentation.
- I have updated the documentation accordingly. (I've added the new field to the swagger files)

SQL FIle with statements:
[game_highlights.zip](https://github.com/CFBD/cfb-api/files/6638895/game_highlights.zip)



<!--- Don't remove or modify anything beneath this line. -->
@BlueSCar
