### PR TITLE
Add routes for fantasy football

### DIFF
--- a/app/game/game.controller.js
+++ b/app/game/game.controller.js
@@ -287,7 +287,7 @@ module.exports = (db, Sentry) => {
                     res.status(400).send({
                         error: 'Must specify a gameId or a year with either a week, team, or conference.'
                     });
-
+ 
                     return;
                 }
 
@@ -637,6 +637,23 @@ module.exports = (db, Sentry) => {
             try {
                 const scoreboard = await service.getScoreboard(req.query.classification, req.query.conference);
                 res.send(scoreboard);
+            } catch (err) {
+                Sentry.captureException(err);
+                res.status(500).send({
+                    error: 'Something went wrong.'
+                });
+            }
+        },
+        getPlayerStatsByWeek: async (req, res) => {
+            try {
+                if (!req.query.week || !req.query.athleteId) {
+                    res.status(400).send({
+                        error: 'athletId and week must be specified'
+                    });
+                } else {
+                    const data = await service.getPlayerStatsByWeek(req.query.week, req.query.athleteId);
+                    res.send(data);
+                }
             } catch (err) {
                 Sentry.captureException(err);
                 res.status(500).send({

--- a/app/game/game.route.js
+++ b/app/game/game.route.js
@@ -10,4 +10,5 @@ module.exports = (app, db, middlewares, Sentry, patreonMiddlewares) => {
     app.route('/calendar').get(middlewares, controller.getCalendar);
     app.route('/games/weather').get(patreonMiddlewares, controller.getWeather);
     app.route('/scoreboard').get(patreonMiddlewares, controller.getScoreboard);
+    app.route('/player/stats').get(middlewares, controller.getPlayerStatsByWeek);
 }

--- a/app/game/game.service.js
+++ b/app/game/game.service.js
@@ -452,11 +452,31 @@ module.exports = (db) => {
         }));
     };
 
+    const getPlayerStatsByWeek = async (week, playerId) => {
+        const stats = await db.any(`
+            SELECT gps.*
+            FROM game_player_stat gps
+            JOIN game_team gt ON gps.game_team_id = gt.id
+            JOIN game g ON gt.game_id = g.id
+            WHERE g.week = ${week} AND gps.athlete_id = ${playerId};
+        `);
+
+        return stats.map(s => ({
+            id: s.id,
+            gameTeamId: s.game_team_id,
+            athleteId: s.athlete_id,
+            categoryId: s.category_id,
+            typeId: s.type_id,
+            stat: s.stat
+        }));
+    };
+
     return {
         getDrives,
         getMedia,
         getCalendar,
         getWeather,
-        getScoreboard
+        getScoreboard,
+        getPlayerStatsByWeek
     };
 };

--- a/app/play/play.controller.js
+++ b/app/play/play.controller.js
@@ -7,7 +7,7 @@ module.exports = (db, Sentry) => {
         try {
             let types = await service.getPlayTypes();
             res.send(types);
-        } catch (err) {
+        } catch (err) { 
             Sentry.captureException(err);
             res.status(500).send({
                 error: 'Something went wrong.'

--- a/app/player/player.controller.js
+++ b/app/player/player.controller.js
@@ -19,7 +19,7 @@ module.exports = (db, Sentry) => {
             }
         } catch (err) {
             Sentry.captureException(err);
-            res.status(500).send({
+            res.status(500).send({ 
                 error: 'Something went wrong.'
             });
         }
@@ -152,12 +152,57 @@ module.exports = (db, Sentry) => {
         }
     };
 
+    const getActivePlayers = async (req, res) => {
+        try {
+            const data = await service.getActivePlayers();
+            res.send(data);
+        } catch (err) {
+            Sentry.captureException(err);
+            res.status(500).send({
+                error: 'Something went wrong.'
+            });
+        }
+    };
+
+    const getActivePowerFivePlayers = async (req, res) => {
+        try {
+            const data = await service.getActivePowerFivePlayers();
+            res.send(data);
+        } catch (err) {
+            Sentry.captureException(err);
+            res.status(500).send({
+                error: 'Something went wrong.'
+            });
+        }
+    }; 
+
+    const getActivePlayersByPosition = async (req, res) => {
+        try {
+            if (!req.query.positionId) {
+                res.status(400).send({
+                    error: 'position id must be specified'
+                });
+            } else {
+                const data = await service.getActivePlayersByPosition(req.query.positionId);
+                res.send(data);
+            }
+        } catch (err) {
+            Sentry.captureException(err);
+            res.status(500).send({
+                error: 'Something went wrong.'
+            });
+        }
+    };
+
     return {
         playerSearch,
         getMeanPassingPPA,
         getPlayerUsage,
         getReturningProduction,
         getSeasonStats,
-        getTransferPortal
+        getTransferPortal,
+        getActivePlayers,
+        getActivePowerFivePlayers,
+        getActivePlayersByPosition
     };
 };

--- a/app/player/player.routes.js
+++ b/app/player/player.routes.js
@@ -9,4 +9,7 @@ module.exports = (app, db, middlewares, Sentry) => {
     app.route('/player/returning').get(middlewares, controller.getReturningProduction);
     app.route('/stats/player/season').get(middlewares, controller.getSeasonStats);
     app.route('/player/portal').get(middlewares, controller.getTransferPortal);
-};
+    app.route('/player/active').get(middlewares, controller.getActivePlayers);
+    app.route('/player/active/powerfive').get(middlewares, controller.getActivePowerFivePlayers);
+    app.route('/player/position').get(middlewares, controller.getActivePlayersByPosition);
+}; 

--- a/app/player/player.service.js
+++ b/app/player/player.service.js
@@ -516,12 +516,86 @@ module.exports = (db) => {
         }));
     };
 
+    const getActivePlayers = async () => {
+        let players = await db.any(`
+            SELECT * from athlete
+            WHERE active = true
+        `);
+
+        return players.map(p => ({
+            id: p.id,
+            teamId: p.team_id,
+            name: p.name,
+            firstName: p.first_name,
+            lastName: p.last_name,
+            weight: p.weight,
+            height: p.height,
+            jersey: p.jersey,
+            hometownId: p.hometown_id,
+            positionId: p.position_id,
+            active: p.active,
+            year: p.year
+        }));
+    };
+
+    const getActivePowerFivePlayers = async () => {
+        // need to replace dashed line with IDs of power five conferences
+        let players = await db.any(`
+            SELECT a.*
+            FROM athlete a
+            JOIN athlete_team at ON a.id = at.athlete_id
+            JOIN team t ON at.team_id = t.id
+            JOIN conference_team ct ON t.id = ct.team_id
+            WHERE ct.conference_id IN ---------;
+        `);
+
+        return players.map(p => ({
+            id: p.id,
+            teamId: p.team_id,
+            name: p.name,
+            firstName: p.first_name,
+            lastName: p.last_name,
+            weight: p.weight,
+            height: p.height,
+            jersey: p.jersey,
+            hometownId: p.hometown_id,
+            positionId: p.position_id,
+            active: p.active,
+            year: p.year
+        }));
+    };
+
+    const getActivePlayersByPosition = async (positionId) => {
+        let players = await db.any(`
+            SELECT * from athlete
+            WHERE position_id = ${positionId}
+        `);
+
+        return players.map(p => ({
+            id: p.id,
+            teamId: p.team_id,
+            name: p.name,
+            firstName: p.first_name,
+            lastName: p.last_name,
+            weight: p.weight,
+            height: p.height,
+            jersey: p.jersey,
+            hometownId: p.hometown_id,
+            positionId: p.position_id,
+            active: p.active,
+            year: p.year
+        }));
+    };
+
     return {
         playerSearch,
         getMeanPassingChartData,
         getPlayerUsage,
         getReturningProduction,
         getSeasonStats,
-        getTransferPortal
+        getTransferPortal,
+        getActivePlayers,
+        getActivePowerFivePlayers,
+        getActivePlayersByPosition
     };
 };

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+swagger: "2.0"
 info:
   description: This is an API for accessing all sorts of college football data.  Please note that API keys should be supplied with "Bearer " prepended (e.g. "Bearer your_key"). API keys can be acquired from the CollegeFootballData.com website.
   version: 4.4.13
@@ -108,13 +108,13 @@ paths:
           required: false
           type: integer
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/Game'
-        '400':
+              $ref: "#/definitions/Game"
+        "400":
           description: error
   /scoreboard:
     get:
@@ -137,14 +137,45 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/ScoreboardGame'
-        '400':
+              $ref: "#/definitions/ScoreboardGame"
+        "400":
           description: error
+  /player/stats:
+    get:
+      tags:
+        - games
+      summary: Individual player stats
+      description: Get a player's stats for a given week
+      operationId: getPlayerStats
+      produces:
+        - application/json
+      parameters:
+        - name: week
+          description: Week of season the game took place
+          in: query
+          required: true
+          type: integer
+          minimum: 0
+        - name: athleteId
+          description: The database id of the athlete
+          in: query
+          required: true
+          type: integer
+          minimum: 0
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: array
+        "400":
+          description: error, failed to include required parameter
+        "500":
+          description: erro, unknown cause
   /records:
     get:
       tags:
@@ -172,13 +203,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/TeamRecord'
-        '400':
+              $ref: "#/definitions/TeamRecord"
+        "400":
           description: error
   /calendar:
     get:
@@ -196,13 +227,13 @@ paths:
           required: true
           type: integer
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/Week'
-        '400':
+              $ref: "#/definitions/Week"
+        "400":
           description: error
   /games/media:
     get:
@@ -253,13 +284,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/GameMedia'
-        '400':
+              $ref: "#/definitions/GameMedia"
+        "400":
           description: error
   /games/weather:
     get:
@@ -310,13 +341,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/GameWeather'
-        '400':
+              $ref: "#/definitions/GameWeather"
+        "400":
           description: error
   /games/players:
     get:
@@ -368,13 +399,13 @@ paths:
           required: false
           type: integer
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/PlayerGame'
-        '400':
+              $ref: "#/definitions/PlayerGame"
+        "400":
           description: error
   /games/teams:
     get:
@@ -426,13 +457,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/TeamGame'
-        '400':
+              $ref: "#/definitions/TeamGame"
+        "400":
           description: error
   /game/box/advanced:
     get:
@@ -450,10 +481,10 @@ paths:
           required: true
           type: integer
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
-            $ref: '#/definitions/BoxScore'
+            $ref: "#/definitions/BoxScore"
   /drives:
     get:
       tags:
@@ -519,12 +550,12 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/Drive'
+              $ref: "#/definitions/Drive"
   /plays:
     get:
       tags:
@@ -548,7 +579,7 @@ paths:
           type: integer
           minimum: 2001
         - name: week
-          description: 'Week filter (required if team, offense, or defense, not specified)'
+          description: "Week filter (required if team, offense, or defense, not specified)"
           in: query
           required: true
           type: integer
@@ -595,12 +626,12 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/Play'
+              $ref: "#/definitions/Play"
   /live/plays:
     get:
       tags:
@@ -617,10 +648,10 @@ paths:
           required: true
           type: integer
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
-              $ref: '#/definitions/LivePlayByPlay'
+            $ref: "#/definitions/LivePlayByPlay"
   /play/types:
     get:
       tags:
@@ -631,12 +662,12 @@ paths:
       produces:
         - application/json
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/PlayType'
+              $ref: "#/definitions/PlayType"
   /play/stats:
     get:
       tags:
@@ -691,13 +722,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/PlayStat'
-        '400':
+              $ref: "#/definitions/PlayStat"
+        "400":
           description: error
   /play/stat/types:
     get:
@@ -709,13 +740,13 @@ paths:
       produces:
         - application/json
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/PlayStatType'
-        '400':
+              $ref: "#/definitions/PlayStatType"
+        "400":
           description: error
   /conferences:
     get:
@@ -727,13 +758,13 @@ paths:
       produces:
         - application/json
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/Conference'
-        '400':
+              $ref: "#/definitions/Conference"
+        "400":
           description: error
   /teams:
     get:
@@ -751,13 +782,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/Team'
-        '400':
+              $ref: "#/definitions/Team"
+        "400":
           description: error
   /teams/fbs:
     get:
@@ -776,13 +807,13 @@ paths:
           type: integer
           minimum: 1869
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/Team'
-        '400':
+              $ref: "#/definitions/Team"
+        "400":
           description: error
   /roster:
     get:
@@ -806,13 +837,13 @@ paths:
           type: integer
           minimum: 2009
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/Player'
-        '400':
+              $ref: "#/definitions/Player"
+        "400":
           description: error
   /talent:
     get:
@@ -831,13 +862,13 @@ paths:
           type: integer
           minimum: 2015
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/TeamTalent'
-        '400':
+              $ref: "#/definitions/TeamTalent"
+        "400":
           description: error
   /teams/matchup:
     get:
@@ -872,11 +903,11 @@ paths:
           type: integer
           minimum: 1869
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
-              $ref: '#/definitions/TeamMatchup'
-        '400':
+            $ref: "#/definitions/TeamMatchup"
+        "400":
           description: error
   /venues:
     get:
@@ -888,13 +919,13 @@ paths:
       produces:
         - application/json
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/Venue'
-        '400':
+              $ref: "#/definitions/Venue"
+        "400":
           description: error
   /coaches:
     get:
@@ -940,12 +971,12 @@ paths:
           type: integer
           minimum: 1869
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/Coach'
+              $ref: "#/definitions/Coach"
   /rankings:
     get:
       tags:
@@ -976,13 +1007,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/RankingWeek'
-        '400':
+              $ref: "#/definitions/RankingWeek"
+        "400":
           description: error
   /lines:
     get:
@@ -1039,13 +1070,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/GameLines'
-        '400':
+              $ref: "#/definitions/GameLines"
+        "400":
           description: error
   /recruiting/players:
     get:
@@ -1064,7 +1095,7 @@ paths:
           type: integer
           minimum: 2000
         - name: classification
-          description: 'Type of recruit (HighSchool, JUCO, PrepSchool)'
+          description: "Type of recruit (HighSchool, JUCO, PrepSchool)"
           default: HighSchool
           in: query
           required: false
@@ -1085,13 +1116,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/Recruit'
-        '400':
+              $ref: "#/definitions/Recruit"
+        "400":
           description: error
   /recruiting/teams:
     get:
@@ -1115,13 +1146,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/TeamRecruitingRank'
-        '400':
+              $ref: "#/definitions/TeamRecruitingRank"
+        "400":
           description: error
   /recruiting/groups:
     get:
@@ -1156,13 +1187,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/PositionGroupRecruitingRating'
-        '400':
+              $ref: "#/definitions/PositionGroupRecruitingRating"
+        "400":
           description: error
   /ratings/sp:
     get:
@@ -1186,13 +1217,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/TeamSPRating'
-        '400':
+              $ref: "#/definitions/TeamSPRating"
+        "400":
           description: error
   /ratings/srs:
     get:
@@ -1221,13 +1252,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/TeamSRSRating'
-        '400':
+              $ref: "#/definitions/TeamSRSRating"
+        "400":
           description: error
   /ratings/sp/conferences:
     get:
@@ -1251,13 +1282,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/ConferenceSPRating'
-        '400':
+              $ref: "#/definitions/ConferenceSPRating"
+        "400":
           description: error
   /ratings/elo:
     get:
@@ -1290,13 +1321,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/TeamEloRating'
-        '400':
+              $ref: "#/definitions/TeamEloRating"
+        "400":
           description: error
   /ppa/predicted:
     get:
@@ -1323,13 +1354,13 @@ paths:
           minimum: 1
           maximum: 99
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/PredictedPoints'
-        '400':
+              $ref: "#/definitions/PredictedPoints"
+        "400":
           description: error
   /ppa/teams:
     get:
@@ -1363,13 +1394,13 @@ paths:
           required: false
           type: boolean
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/TeamPPA'
-        '400':
+              $ref: "#/definitions/TeamPPA"
+        "400":
           description: error
   /ppa/games:
     get:
@@ -1416,13 +1447,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/GamePPA'
-        '400':
+              $ref: "#/definitions/GamePPA"
+        "400":
           description: error
   /ppa/players/games:
     get:
@@ -1479,13 +1510,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/PlayerGamePPA'
-        '400':
+              $ref: "#/definitions/PlayerGamePPA"
+        "400":
           description: error
   /ppa/players/season:
     get:
@@ -1534,13 +1565,13 @@ paths:
           required: false
           type: boolean
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/PlayerSeasonPPA'
-        '400':
+              $ref: "#/definitions/PlayerSeasonPPA"
+        "400":
           description: error
   /metrics/wp:
     get:
@@ -1558,13 +1589,13 @@ paths:
           required: true
           type: integer
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/PlayWP'
-        '400':
+              $ref: "#/definitions/PlayWP"
+        "400":
           description: error
   /metrics/wp/pregame:
     get:
@@ -1600,13 +1631,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/PregameWP'
-        '400':
+              $ref: "#/definitions/PregameWP"
+        "400":
           description: error
   /stats/season:
     get:
@@ -1649,13 +1680,13 @@ paths:
           minimum: 1
           maximum: 16
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/TeamSeasonStat'
-        '400':
+              $ref: "#/definitions/TeamSeasonStat"
+        "400":
           description: error
   /stats/season/advanced:
     get:
@@ -1698,13 +1729,13 @@ paths:
           minimum: 1
           maximum: 16
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/AdvancedSeasonStat'
-        '400':
+              $ref: "#/definitions/AdvancedSeasonStat"
+        "400":
           description: error
   /stats/game/advanced:
     get:
@@ -1750,13 +1781,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/AdvancedGameStat'
-        '400':
+              $ref: "#/definitions/AdvancedGameStat"
+        "400":
           description: error
   /stats/categories:
     get:
@@ -1768,7 +1799,7 @@ paths:
       produces:
         - application/json
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
@@ -1806,13 +1837,13 @@ paths:
           type: integer
           minimum: 2001
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/PlayerSearchResult'
-        '400':
+              $ref: "#/definitions/PlayerSearchResult"
+        "400":
           description: error
   /player/usage:
     get:
@@ -1857,13 +1888,13 @@ paths:
           required: false
           type: boolean
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/PlayerUsage'
-        '400':
+              $ref: "#/definitions/PlayerUsage"
+        "400":
           description: error
   /player/returning:
     get:
@@ -1892,13 +1923,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/ReturningProduction'
-        '400':
+              $ref: "#/definitions/ReturningProduction"
+        "400":
           description: error
   /stats/player/season:
     get:
@@ -1946,13 +1977,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/PlayerSeasonStat'
-        '400':
+              $ref: "#/definitions/PlayerSeasonStat"
+        "400":
           description: error
   /player/portal:
     get:
@@ -1970,14 +2001,70 @@ paths:
           required: true
           type: integer
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/PortalPlayer'
-        '400':
+              $ref: "#/definitions/PortalPlayer"
+        "400":
           description: error
+  /player/active:
+    get:
+      tags:
+        - players
+      summary: Get all active players
+      description: All active players
+      operationId: getActivePlayers
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            type: array
+        "500":
+          description: error, unknown origin
+    /player/active/powerfive:
+      get:
+        tags:
+          - players
+        summary: Get all active power five players
+        description: All active power five players
+        operationId: getActivePowerFivePlayers
+        produces:
+          - application/json
+        responses:
+          "200":
+            description: successful operation
+            schema:
+              type: array
+          "500":
+            description: error, unknown origin
+  /player/position:
+    get:
+      tags:
+        - players
+      summary: Get all active players at a given position
+      description: All active players at a given position
+      operationId: getActivePlayersByPosition
+      produces:
+        - application/json
+      parameters:
+        - name: positionId
+          description: Id of position looking for (include QB = 1, RB = 2 but idk what id goes with what position)
+          in: query
+          required: true
+          type: integer
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            type: array
+        "400":
+          description: error, failed to include positionId
+        "500":
+          description: error, unknown origin
   /draft/teams:
     get:
       tags:
@@ -1988,13 +2075,13 @@ paths:
       produces:
         - application/json
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/DraftTeam'
-        '400':
+              $ref: "#/definitions/DraftTeam"
+        "400":
           description: error
   /draft/positions:
     get:
@@ -2006,13 +2093,13 @@ paths:
       produces:
         - application/json
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/DraftPosition'
-        '400':
+              $ref: "#/definitions/DraftPosition"
+        "400":
           description: error
   /draft/picks:
     get:
@@ -2050,13 +2137,13 @@ paths:
           required: false
           type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/DraftPick'
-        '400':
+              $ref: "#/definitions/DraftPick"
+        "400":
           description: error
 definitions:
   Game:
@@ -2645,7 +2732,7 @@ definitions:
         properties:
           x:
             type: number
-          'y':
+          "y":
             type: number
       elevation:
         type: number
@@ -3173,7 +3260,7 @@ definitions:
         type: integer
   PregameWP:
     type: object
-    properties: 
+    properties:
       season:
         type: integer
       seasonType:
@@ -3289,7 +3376,7 @@ definitions:
             type: number
           fieldPosition:
             type: object
-            properties: 
+            properties:
               averageStart:
                 type: number
               averagePredictedPoints:
@@ -3388,7 +3475,7 @@ definitions:
             type: number
           fieldPosition:
             type: object
-            properties: 
+            properties:
               averageStart:
                 type: number
               averagePredictedPoints:
@@ -3634,7 +3721,7 @@ definitions:
         type: string
   PlayerGamePPA:
     type: object
-    properties: 
+    properties:
       season:
         type: integer
       week:
@@ -3649,7 +3736,7 @@ definitions:
         type: string
       averagePPA:
         type: object
-        properties: 
+        properties:
           all:
             type: number
           pass:
@@ -3658,7 +3745,7 @@ definitions:
             type: number
   PlayerSeasonPPA:
     type: object
-    properties: 
+    properties:
       season:
         type: integer
       id:
@@ -3673,7 +3760,7 @@ definitions:
         type: string
       averagePPA:
         type: object
-        properties: 
+        properties:
           all:
             type: number
           pass:
@@ -3692,7 +3779,7 @@ definitions:
             type: number
       totalPPA:
         type: object
-        properties: 
+        properties:
           all:
             type: number
           pass:
@@ -3711,7 +3798,7 @@ definitions:
             type: number
   PlayerUsage:
     type: object
-    properties: 
+    properties:
       season:
         type: integer
       id:
@@ -3726,7 +3813,7 @@ definitions:
         type: string
       usage:
         type: object
-        properties: 
+        properties:
           overall:
             type: number
           pass:
@@ -3786,14 +3873,14 @@ definitions:
             type: array
             items:
               type: object
-              properties: 
+              properties:
                 team:
                   type: string
                 plays:
                   type: number
                 overall:
                   type: object
-                  properties: 
+                  properties:
                     total:
                       type: number
                     quarter1:
@@ -3806,7 +3893,7 @@ definitions:
                       type: number
                 passing:
                   type: object
-                  properties: 
+                  properties:
                     total:
                       type: number
                     quarter1:
@@ -3819,7 +3906,7 @@ definitions:
                       type: number
                 rushing:
                   type: object
-                  properties: 
+                  properties:
                     total:
                       type: number
                     quarter1:
@@ -3834,14 +3921,14 @@ definitions:
             type: array
             items:
               type: object
-              properties: 
+              properties:
                 team:
                   type: string
                 plays:
                   type: number
                 overall:
                   type: object
-                  properties: 
+                  properties:
                     total:
                       type: number
                     quarter1:
@@ -3854,7 +3941,7 @@ definitions:
                       type: number
                 passing:
                   type: object
-                  properties: 
+                  properties:
                     total:
                       type: number
                     quarter1:
@@ -3867,7 +3954,7 @@ definitions:
                       type: number
                 rushing:
                   type: object
-                  properties: 
+                  properties:
                     total:
                       type: number
                     quarter1:
@@ -3882,12 +3969,12 @@ definitions:
             type: array
             items:
               type: object
-              properties: 
+              properties:
                 team:
                   type: string
                 overall:
                   type: object
-                  properties: 
+                  properties:
                     total:
                       type: number
                     quarter1:
@@ -3900,7 +3987,7 @@ definitions:
                       type: number
                 standardDowns:
                   type: object
-                  properties: 
+                  properties:
                     total:
                       type: number
                     quarter1:
@@ -3913,7 +4000,7 @@ definitions:
                       type: number
                 passingDowns:
                   type: object
-                  properties: 
+                  properties:
                     total:
                       type: number
                     quarter1:
@@ -3928,12 +4015,12 @@ definitions:
             type: array
             items:
               type: object
-              properties: 
+              properties:
                 team:
                   type: string
                 overall:
                   type: object
-                  properties: 
+                  properties:
                     total:
                       type: number
                     quarter1:
@@ -3997,7 +4084,7 @@ definitions:
             type: array
             items:
               type: object
-              properties: 
+              properties:
                 team:
                   type: string
                 averageStart:


### PR DESCRIPTION
# Add routes for fantasy football 

## Description
I added four routes to the api,
- /player/active: gets all active players
- /player/active/powerfive: gets all active power five players
- /player/position: gets all active players in a given position
- /player/stats: gets a player's stats for a given week of the season

## Motivation and Context
I made these changes because my friend and wanted to make a college fantasy football app for fun, and this seemed like the best open source option for that. However, I found the current api routes lacking to get some of the data needed for fantasy football so I added routes to fix that. 

## How Has This Been Tested?
I haven't done any real testing on this because I don't have a great test environment setup. I've checked the more complex sql queries in perplexity.ai, other than that I didn't really test anything because I don't have a database setup to test on. I'm confident this won't affect any other parts of the code because I only added routes completely independent of other portions of code. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly. // I've never used swagger docs before but I think I followed the template correctly. 


<!--- Don't remove or modify anything beneath this line. -->
@BlueSCar
